### PR TITLE
doOutput() in doRest() to modify its pointer only in safe ways.

### DIFF
--- a/user.go
+++ b/user.go
@@ -145,18 +145,12 @@ func (u Users) Update(user *User) error {
 	if user.ID == nil || *user.ID == "" {
 		return fmt.Errorf("user ID field is not set")
 	}
-	var updatedUser User
-	err := doRest(
+	return doRest(
 		"PUT",
 		fmt.Sprintf("%s/%s", baseUserPath, *user.ID),
 		u.client,
 		doInput(user),
-		doOutput(&updatedUser))
-	if err != nil {
-		return err
-	}
-	*user = updatedUser
-	return nil
+		doOutput(user))
 }
 
 // Deletes the specified user


### PR DESCRIPTION
Without this change, JSON structs can change in strange ways after
assignment. This is because when the go json package unmarshals, it
modified slices and maps within a struct in place. The way to fix this
is to set the struct to its zero value before unmarshalling. Since the
zero value has no allocated slices or maps, the json library will
allocate new slices and maps rather than modifying existing ones in
place which is what we need for the assignment operator to work as
intended.