### PR TITLE
In dashboard, add omitemtpy to ScatterPlotSource.

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -160,7 +160,7 @@ type Source struct {
 	Disabled bool `json:"disabled,omitempty"`
 
 	// ScatterPlotSource
-	ScatterPlotSource string `json:"scatterPlotSource"`
+	ScatterPlotSource string `json:"scatterPlotSource,omitempty"`
 
 	// QuerybuilderEnabled
 	QuerybuilderEnabled bool `json:"querybuilderEnabled"`


### PR DESCRIPTION
This change is needed because ScatterPlotSource must be either "X", "Y" or
omitted completely. Therefore if ScatterPlotSource is left the empty string, it
should be omitted. Without this change, creating a dashboard fails whenever
a Source doesn't have an explicit ScatterPlotSource.