### PR TITLE
Rename doOutput() to doResponse() and doInput() to doPayload().

### DIFF
--- a/access_control_lists.go
+++ b/access_control_lists.go
@@ -28,5 +28,5 @@ func putEntityACL(id string, canView []string, canModify []string, basePath stri
 		"PUT",
 		fmt.Sprintf("%s/acl/set", basePath),
 		client,
-		doInput(acls))
+		doPayload(acls))
 }

--- a/alert.go
+++ b/alert.go
@@ -142,7 +142,7 @@ func (a Alerts) Get(alert *Alert) error {
 		"GET",
 		fmt.Sprintf("%s/%s", baseAlertPath, *alert.ID),
 		a.client,
-		doOutput(alert))
+		doResponse(alert))
 }
 
 // Find returns all alerts filtered by the given search conditions.
@@ -183,8 +183,8 @@ func (a Alerts) Create(alert *Alert) error {
 		"POST",
 		baseAlertPath,
 		a.client,
-		doInput(alert),
-		doOutput(alert))
+		doPayload(alert),
+		doResponse(alert))
 }
 
 // Update is used to update an existing Alert.
@@ -198,8 +198,8 @@ func (a Alerts) Update(alert *Alert) error {
 		"PUT",
 		fmt.Sprintf("%s/%s", baseAlertPath, *alert.ID),
 		a.client,
-		doInput(alert),
-		doOutput(alert))
+		doPayload(alert),
+		doResponse(alert))
 }
 
 // Delete is used to delete an existing Alert.

--- a/client_test.go
+++ b/client_test.go
@@ -233,7 +233,7 @@ func TestDoRest_UnexpectedResponse(t *testing.T) {
 		"POST",
 		"/a/rest/path",
 		fake,
-		doOutput(&result))
+		doResponse(&result))
 	assert.Error(err)
 }
 
@@ -262,8 +262,8 @@ func TestDoRest(t *testing.T) {
 		"POST",
 		"/a/rest/path",
 		fake,
-		doInput(&testPointType{X: 3, Y: 5}),
-		doOutput(&result),
+		doPayload(&testPointType{X: 3, Y: 5}),
+		doResponse(&result),
 		paramOption)
 	assert.NoError(err)
 	assert.Equal("POST", fake.method)
@@ -299,8 +299,7 @@ func TestDoRest_DirectResponse(t *testing.T) {
 		"GET",
 		"/a/rest/path",
 		fake,
-		doOutput(&result),
-		doDirectResponse())
+		doDirectResponse(&result))
 	assert.NoError(err)
 	assert.Equal("GET", fake.method)
 	assert.Equal("/a/rest/path", fake.path)
@@ -324,8 +323,7 @@ func TestDoRest_SafeModify(t *testing.T) {
 		"GET",
 		"/a/rest/path",
 		fake,
-		doOutput(&result),
-		doDirectResponse()))
+		doDirectResponse(&result)))
 	assert.Equal([]int{2, 3, 5}, result.Primes)
 
 	// doRest should modify result in such a way that the slice from the
@@ -352,7 +350,7 @@ func TestDoRest_SafeModifyResponse(t *testing.T) {
 		"GET",
 		"/a/rest/path",
 		fake,
-		doOutput(&result)))
+		doResponse(&result)))
 	assert.Equal([]int{2, 3, 5}, result.Primes)
 
 	// doRest should modify result in such a way that the slice from the

--- a/cloud_integration.go
+++ b/cloud_integration.go
@@ -286,7 +286,7 @@ func (ci CloudIntegrations) Get(cloudIntegration *CloudIntegration) error {
 		"GET",
 		fmt.Sprintf("%s/%s", baseCloudIntegrationPath, cloudIntegration.Id),
 		ci.client,
-		doOutput(cloudIntegration))
+		doResponse(cloudIntegration))
 }
 
 // Deletes a given CloudIntegration and sets the ID of the object to ""
@@ -320,8 +320,8 @@ func (ci CloudIntegrations) Update(cloudIntegration *CloudIntegration) error {
 		"PUT",
 		fmt.Sprintf("%s/%s", baseCloudIntegrationPath, cloudIntegration.Id),
 		ci.client,
-		doInput(cloudIntegration),
-		doOutput(cloudIntegration))
+		doPayload(cloudIntegration),
+		doResponse(cloudIntegration))
 }
 
 // Creates a CloudIntegration in Wavefront
@@ -331,8 +331,8 @@ func (ci CloudIntegrations) Create(cloudIntegration *CloudIntegration) error {
 		"POST",
 		baseCloudIntegrationPath,
 		ci.client,
-		doInput(cloudIntegration),
-		doOutput(cloudIntegration))
+		doPayload(cloudIntegration),
+		doResponse(cloudIntegration))
 }
 
 // Creates an AWS ExternalID for use in AWS IAM Roles
@@ -342,7 +342,7 @@ func (ci CloudIntegrations) CreateAwsExternalID() (string, error) {
 		"POST",
 		fmt.Sprintf("%s/awsExternalId", baseCloudIntegrationPath),
 		ci.client,
-		doOutput(&externalId))
+		doResponse(&externalId))
 	return externalId, err
 }
 

--- a/dashboard.go
+++ b/dashboard.go
@@ -320,8 +320,8 @@ func (d Dashboards) Create(dashboard *Dashboard) error {
 		"POST",
 		baseDashboardPath,
 		d.client,
-		doInput(dashboard),
-		doOutput(dashboard))
+		doPayload(dashboard),
+		doResponse(dashboard))
 }
 
 // Update is used to update an existing Dashboard.
@@ -335,8 +335,8 @@ func (d Dashboards) Update(dashboard *Dashboard) error {
 		"PUT",
 		fmt.Sprintf("%s/%s", baseDashboardPath, dashboard.ID),
 		d.client,
-		doInput(dashboard),
-		doOutput(dashboard))
+		doPayload(dashboard),
+		doResponse(dashboard))
 }
 
 // Get is used to retrieve an existing Dashboard by ID.
@@ -350,7 +350,7 @@ func (d Dashboards) Get(dashboard *Dashboard) error {
 		"GET",
 		fmt.Sprintf("%s/%s", baseDashboardPath, dashboard.ID),
 		d.client,
-		doOutput(dashboard))
+		doResponse(dashboard))
 }
 
 // Delete is used to delete an existing Dashboard.
@@ -384,7 +384,7 @@ func (d Dashboards) SetTags(id string, tags []string) error {
 		"POST",
 		fmt.Sprintf("%s/%s/tag", baseDashboardPath, id),
 		d.client,
-		doInput(tags))
+		doPayload(tags))
 }
 
 // Sets the ACL on the dashboard with the supplied list of IDs for canView and canModify

--- a/derivedmetric.go
+++ b/derivedmetric.go
@@ -58,7 +58,7 @@ func (dm DerivedMetrics) Get(metric *DerivedMetric) error {
 		"GET",
 		fmt.Sprintf("%s/%s", baseDerivedMetricsPath, *metric.ID),
 		dm.client,
-		doOutput(metric))
+		doResponse(metric))
 }
 
 // Find returns all DerivedMetrics filtered by the given search conditions.
@@ -102,8 +102,8 @@ func (dm DerivedMetrics) Create(metric *DerivedMetric) error {
 		"POST",
 		baseDerivedMetricsPath,
 		dm.client,
-		doInput(metric),
-		doOutput(metric))
+		doPayload(metric),
+		doResponse(metric))
 }
 
 // Update a DerivedMetric all fields are optional except for ID
@@ -116,8 +116,8 @@ func (dm DerivedMetrics) Update(metric *DerivedMetric) error {
 		"PUT",
 		fmt.Sprintf("%s/%s", baseDerivedMetricsPath, *metric.ID),
 		dm.client,
-		doInput(metric),
-		doOutput(metric))
+		doPayload(metric),
+		doResponse(metric))
 }
 
 // Delete a DerivedMetric all fields are optional except for ID

--- a/event.go
+++ b/event.go
@@ -152,8 +152,8 @@ func (e Events) Create(event *Event) error {
 		"POST",
 		baseEventPath,
 		e.client,
-		doInput(event),
-		doOutput(event))
+		doPayload(event),
+		doResponse(event))
 }
 
 // Update is used to update an existing Event.
@@ -167,8 +167,8 @@ func (e Events) Update(event *Event) error {
 		"PUT",
 		fmt.Sprintf("%s/%s", baseEventPath, *event.ID),
 		e.client,
-		doInput(event),
-		doOutput(event))
+		doPayload(event),
+		doResponse(event))
 }
 
 // Close is used to close an existing Event
@@ -181,7 +181,7 @@ func (e Events) Close(event *Event) error {
 		"POST",
 		fmt.Sprintf("%s/%s/close", baseEventPath, *event.ID),
 		e.client,
-		doOutput(event),
+		doResponse(event),
 	)
 }
 

--- a/externallinks.go
+++ b/externallinks.go
@@ -67,7 +67,7 @@ func (e ExternalLinks) Get(link *ExternalLink) error {
 		"GET",
 		fmt.Sprintf("%s/%s", baseExtLinkPath, *link.ID),
 		e.client,
-		doOutput(link))
+		doResponse(link))
 }
 
 func (e ExternalLinks) Create(link *ExternalLink) error {
@@ -78,8 +78,8 @@ func (e ExternalLinks) Create(link *ExternalLink) error {
 		"POST",
 		baseExtLinkPath,
 		e.client,
-		doInput(link),
-		doOutput(link))
+		doPayload(link),
+		doResponse(link))
 }
 
 func (e ExternalLinks) Update(link *ExternalLink) error {
@@ -91,8 +91,8 @@ func (e ExternalLinks) Update(link *ExternalLink) error {
 		"PUT",
 		fmt.Sprintf("%s/%s", baseExtLinkPath, *link.ID),
 		e.client,
-		doInput(link),
-		doOutput(link))
+		doPayload(link),
+		doResponse(link))
 }
 
 func (e ExternalLinks) Delete(link *ExternalLink) error {

--- a/maintenancewindow.go
+++ b/maintenancewindow.go
@@ -90,7 +90,7 @@ func (m *MaintenanceWindows) GetByID(id string) (
 		"GET",
 		fmt.Sprintf("%s/%s", maintenanceWindowEndpoint, id),
 		m.client,
-		doOutput(&result))
+		doResponse(&result))
 	if err != nil {
 		return
 	}
@@ -106,8 +106,8 @@ func (m *MaintenanceWindows) Create(options *MaintenanceWindowOptions) (
 		"POST",
 		maintenanceWindowEndpoint,
 		m.client,
-		doInput(options),
-		doOutput(&result))
+		doPayload(options),
+		doResponse(&result))
 	if err != nil {
 		return
 	}
@@ -124,8 +124,8 @@ func (m *MaintenanceWindows) Update(
 		"PUT",
 		fmt.Sprintf("%s/%s", maintenanceWindowEndpoint, id),
 		m.client,
-		doInput(conformOptionsForWavefrontAPI(*options)),
-		doOutput(&result))
+		doPayload(conformOptionsForWavefrontAPI(*options)),
+		doResponse(&result))
 	if err != nil {
 		return
 	}

--- a/role.go
+++ b/role.go
@@ -68,8 +68,8 @@ func (r Roles) Create(role *Role) error {
 		"POST",
 		baseRoleUrlPath,
 		r.client,
-		doInput(role),
-		doOutput(role))
+		doPayload(role),
+		doResponse(role))
 }
 
 // Get a specific Role for the given ID
@@ -83,7 +83,7 @@ func (r Roles) Get(role *Role) error {
 		"GET",
 		fmt.Sprintf("%s/%s", baseRoleUrlPath, role.ID),
 		r.client,
-		doOutput(role))
+		doResponse(role))
 }
 
 // Update a specific Role for the given ID
@@ -97,8 +97,8 @@ func (r Roles) Update(role *Role) error {
 		"PUT",
 		fmt.Sprintf("%s/%s", baseRoleUrlPath, role.ID),
 		r.client,
-		doInput(role),
-		doOutput(role))
+		doPayload(role),
+		doResponse(role))
 }
 
 func (r Roles) Delete(role *Role) error {
@@ -120,8 +120,8 @@ func (r Roles) AddAssignees(assignees []string, role *Role) error {
 		"POST",
 		fmt.Sprintf("%s/%s/addAssignees", baseRoleUrlPath, role.ID),
 		r.client,
-		doInput(assignees),
-		doOutput(role))
+		doPayload(assignees),
+		doResponse(role))
 }
 
 func (r Roles) RemoveAssignees(assignees []string, role *Role) error {
@@ -132,8 +132,8 @@ func (r Roles) RemoveAssignees(assignees []string, role *Role) error {
 		"POST",
 		fmt.Sprintf("%s/%s/removeAssignees", baseRoleUrlPath, role.ID),
 		r.client,
-		doInput(assignees),
-		doOutput(role))
+		doPayload(assignees),
+		doResponse(role))
 }
 
 func (r Roles) GrantPermission(permission string, roles []*Role) error {
@@ -152,7 +152,7 @@ func (r Roles) GrantPermission(permission string, roles []*Role) error {
 		"POST",
 		fmt.Sprintf("%s/grant/%s", baseRoleUrlPath, permission),
 		r.client,
-		doInput(roleIds))
+		doPayload(roleIds))
 }
 
 func (r Roles) RevokePermission(permission string, roles []*Role) error {
@@ -171,5 +171,5 @@ func (r Roles) RevokePermission(permission string, roles []*Role) error {
 		"POST",
 		fmt.Sprintf("%s/%s/%s", baseRoleUrlPath, "revoke", permission),
 		r.client,
-		doInput(roleIds))
+		doPayload(roleIds))
 }

--- a/serviceaccount.go
+++ b/serviceaccount.go
@@ -104,7 +104,7 @@ func (s *ServiceAccounts) GetByID(id string) (
 		"GET",
 		fmt.Sprintf("%s/%s", saEndpoint, id),
 		s.client,
-		doOutput(&result))
+		doResponse(&result))
 	if err != nil {
 		return
 	}
@@ -120,8 +120,8 @@ func (s *ServiceAccounts) Create(options *ServiceAccountOptions) (
 		"POST",
 		saEndpoint,
 		s.client,
-		doInput(fixServiceAccountOptions(*options)),
-		doOutput(&result))
+		doPayload(fixServiceAccountOptions(*options)),
+		doResponse(&result))
 	if err != nil {
 		return
 	}
@@ -137,8 +137,8 @@ func (s *ServiceAccounts) Update(options *ServiceAccountOptions) (
 		"PUT",
 		fmt.Sprintf("%s/%s", saEndpoint, options.ID),
 		s.client,
-		doInput(fixServiceAccountOptions(*options)),
-		doOutput(&result))
+		doPayload(fixServiceAccountOptions(*options)),
+		doResponse(&result))
 	if err != nil {
 		return
 	}

--- a/target.go
+++ b/target.go
@@ -90,7 +90,7 @@ func (t Targets) Get(target *Target) error {
 		"GET",
 		fmt.Sprintf("%s/%s", baseTargetPath, *target.ID),
 		t.client,
-		doOutput(target))
+		doResponse(target))
 }
 
 // Find returns all targets filtered by the given search conditions.
@@ -131,8 +131,8 @@ func (t Targets) Create(target *Target) error {
 		"POST",
 		baseTargetPath,
 		t.client,
-		doInput(target),
-		doOutput(target))
+		doPayload(target),
+		doResponse(target))
 }
 
 // Update is used to update an existing Target.
@@ -146,8 +146,8 @@ func (t Targets) Update(target *Target) error {
 		"PUT",
 		fmt.Sprintf("%s/%s", baseTargetPath, *target.ID),
 		t.client,
-		doInput(target),
-		doOutput(target))
+		doPayload(target),
+		doResponse(target))
 }
 
 // Delete is used to delete an existing Target.

--- a/tokens.go
+++ b/tokens.go
@@ -55,8 +55,8 @@ func (s *Tokens) Create(
 		"POST",
 		fmt.Sprintf("%s/%s", tokenEndpoint, serviceAccountID),
 		s.client,
-		doInput(options),
-		doOutput(&result))
+		doPayload(options),
+		doResponse(&result))
 	if err != nil {
 		return
 	}
@@ -80,8 +80,8 @@ func (s *Tokens) Update(
 		"PUT",
 		fmt.Sprintf("%s/%s/%s", tokenEndpoint, serviceAccountID, options.ID),
 		s.client,
-		doInput(options),
-		doOutput(&result))
+		doPayload(options),
+		doResponse(&result))
 	if err != nil {
 		return
 	}

--- a/user.go
+++ b/user.go
@@ -84,8 +84,7 @@ func (u Users) Get(user *User) error {
 		"GET",
 		fmt.Sprintf("%s/%s", baseUserPath, *user.ID),
 		u.client,
-		doOutput(user),
-		doDirectResponse())
+		doDirectResponse(user))
 }
 
 // Find returns all Users filtered by the given search conditions.
@@ -135,8 +134,8 @@ func (u Users) Create(newUser *NewUserRequest, user *User, sendEmail bool) error
 		baseUserPath,
 		u.client,
 		doParams(params),
-		doInput(newUser),
-		doOutput(user))
+		doPayload(newUser),
+		doResponse(user))
 }
 
 // Supports specifying the credential
@@ -149,8 +148,8 @@ func (u Users) Update(user *User) error {
 		"PUT",
 		fmt.Sprintf("%s/%s", baseUserPath, *user.ID),
 		u.client,
-		doInput(user),
-		doOutput(user))
+		doPayload(user),
+		doResponse(user))
 }
 
 // Deletes the specified user

--- a/usergroup.go
+++ b/usergroup.go
@@ -64,8 +64,8 @@ func (g UserGroups) Create(userGroup *UserGroup) error {
 		"POST",
 		baseUserGroupPath,
 		g.client,
-		doInput(userGroup),
-		doOutput(userGroup))
+		doPayload(userGroup),
+		doResponse(userGroup))
 }
 
 // Gets a specific UserGroup by ID
@@ -79,7 +79,7 @@ func (g UserGroups) Get(userGroup *UserGroup) error {
 		"GET",
 		fmt.Sprintf("%s/%s", baseUserGroupPath, *userGroup.ID),
 		g.client,
-		doOutput(userGroup))
+		doResponse(userGroup))
 }
 
 // Find returns all UsersGroups filtered by the given search conditions.
@@ -125,8 +125,8 @@ func (g UserGroups) Update(userGroup *UserGroup) error {
 		"PUT",
 		fmt.Sprintf("%s/%s", baseUserGroupPath, *userGroup.ID),
 		g.client,
-		doInput(userGroup),
-		doOutput(userGroup))
+		doPayload(userGroup),
+		doResponse(userGroup))
 }
 
 // Adds the specified users to the group
@@ -171,5 +171,5 @@ func (g UserGroups) updateUserGroupUsers(users *[]string, id *string, endpoint s
 		"POST",
 		fmt.Sprintf("%s/%s/%s", baseUserGroupPath, *id, endpoint),
 		g.client,
-		doInput(users))
+		doPayload(users))
 }


### PR DESCRIPTION
This rename makes the code even more clear.  Also doDirectResponse() now
takes a pointer to a struct it no longer has to be used with doResponse().