### PR TITLE
Use reflection to remove duplicate code for Find methods.

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -147,33 +147,9 @@ func (a Alerts) Get(alert *Alert) error {
 
 // Find returns all alerts filtered by the given search conditions.
 // If filter is nil, all alerts are returned.
-func (a Alerts) Find(filter []*SearchCondition) ([]*Alert, error) {
-	search := &Search{
-		client: a.client,
-		Type:   "alert",
-		Params: &SearchParams{
-			Conditions: filter,
-		},
-	}
-
-	var results []*Alert
-	moreItems := true
-	for moreItems {
-		resp, err := search.Execute()
-		if err != nil {
-			return nil, err
-		}
-		var tmpres []*Alert
-		err = json.Unmarshal(resp.Response.Items, &tmpres)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, tmpres...)
-		moreItems = resp.Response.MoreItems
-		search.Params.Offset = resp.NextOffset
-	}
-
-	return results, nil
+func (a Alerts) Find(filter []*SearchCondition) (alerts []*Alert, err error) {
+	err = doSearch(filter, "alert", a.client, &alerts)
+	return
 }
 
 // Create is used to create an Alert in Wavefront.

--- a/cloud_integration.go
+++ b/cloud_integration.go
@@ -1,7 +1,6 @@
 package wavefront
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 )
@@ -247,33 +246,10 @@ func (c *Client) CloudIntegrations() *CloudIntegrations {
 	return &CloudIntegrations{client: c}
 }
 
-func (ci CloudIntegrations) Find(filter []*SearchCondition) ([]*CloudIntegration, error) {
-	search := &Search{
-		client: ci.client,
-		Type:   "cloudintegration",
-		Params: &SearchParams{
-			Conditions: filter,
-		},
-	}
-
-	var results []*CloudIntegration
-	moreItems := true
-	for moreItems {
-		resp, err := search.Execute()
-		if err != nil {
-			return nil, err
-		}
-		var tmpres []*CloudIntegration
-		err = json.Unmarshal(resp.Response.Items, &tmpres)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, tmpres...)
-		moreItems = resp.Response.MoreItems
-		search.Params.Offset = resp.NextOffset
-	}
-
-	return results, nil
+func (ci CloudIntegrations) Find(filter []*SearchCondition) (
+	results []*CloudIntegration, err error) {
+	err = doSearch(filter, "cloudintegration", ci.client, &results)
+	return
 }
 
 // Get a CloudIntegration for a given ID

--- a/dashboard.go
+++ b/dashboard.go
@@ -284,33 +284,10 @@ func (c *Client) Dashboards() *Dashboards {
 
 // Find returns all Dashboards filtered by the given search conditions.
 // If filter is nil, all Dashboards are returned.
-func (d Dashboards) Find(filter []*SearchCondition) ([]*Dashboard, error) {
-	search := &Search{
-		client: d.client,
-		Type:   "dashboard",
-		Params: &SearchParams{
-			Conditions: filter,
-		},
-	}
-
-	var results []*Dashboard
-	moreItems := true
-	for moreItems {
-		resp, err := search.Execute()
-		if err != nil {
-			return nil, err
-		}
-		var tmpres []*Dashboard
-		err = json.Unmarshal(resp.Response.Items, &tmpres)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, tmpres...)
-		moreItems = resp.Response.MoreItems
-		search.Params.Offset = resp.NextOffset
-	}
-
-	return results, nil
+func (d Dashboards) Find(filter []*SearchCondition) (
+	results []*Dashboard, err error) {
+	err = doSearch(filter, "dashboard", d.client, &results)
+	return
 }
 
 // Create is used to create an Dashboard in Wavefront.

--- a/derivedmetric.go
+++ b/derivedmetric.go
@@ -1,7 +1,6 @@
 package wavefront
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 )
@@ -63,33 +62,10 @@ func (dm DerivedMetrics) Get(metric *DerivedMetric) error {
 
 // Find returns all DerivedMetrics filtered by the given search conditions.
 // If filter is nil, all DerivedMetrics are returned.
-func (dm DerivedMetrics) Find(filter []*SearchCondition) ([]*DerivedMetric, error) {
-	search := &Search{
-		client: dm.client,
-		Type:   "derivedmetric",
-		Params: &SearchParams{
-			Conditions: filter,
-		},
-	}
-
-	var results []*DerivedMetric
-	moreItems := true
-	for moreItems {
-		resp, err := search.Execute()
-		if err != nil {
-			return nil, err
-		}
-		var tmpres []*DerivedMetric
-		err = json.Unmarshal(resp.Response.Items, &tmpres)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, tmpres...)
-		moreItems = resp.Response.MoreItems
-		search.Params.Offset = resp.NextOffset
-	}
-
-	return results, nil
+func (dm DerivedMetrics) Find(filter []*SearchCondition) (
+	results []*DerivedMetric, err error) {
+	err = doSearch(filter, "derivedmetric", dm.client, &results)
+	return
 }
 
 // Create a DerivedMetric, name, query, and minutes are required

--- a/externallinks.go
+++ b/externallinks.go
@@ -1,7 +1,6 @@
 package wavefront
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
@@ -30,33 +29,10 @@ func (c *Client) ExternalLinks() *ExternalLinks {
 	return &ExternalLinks{client: c}
 }
 
-func (e ExternalLinks) Find(conditions []*SearchCondition) ([]*ExternalLink, error) {
-	search := Search{
-		client: e.client,
-		Type:   "extlink",
-		Params: &SearchParams{
-			Conditions: conditions,
-		},
-	}
-
-	var results []*ExternalLink
-	moreItems := true
-	for moreItems {
-		resp, err := search.Execute()
-		if err != nil {
-			return nil, err
-		}
-		var tmpres []*ExternalLink
-		err = json.Unmarshal(resp.Response.Items, &tmpres)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, tmpres...)
-		moreItems = resp.Response.MoreItems
-		search.Params.Offset = resp.NextOffset
-	}
-
-	return results, nil
+func (e ExternalLinks) Find(conditions []*SearchCondition) (
+	results []*ExternalLink, err error) {
+	err = doSearch(conditions, "extlink", e.client, &results)
+	return
 }
 
 func (e ExternalLinks) Get(link *ExternalLink) error {

--- a/maintenancewindow.go
+++ b/maintenancewindow.go
@@ -79,6 +79,14 @@ func (c *Client) MaintenanceWindows() *MaintenanceWindows {
 	return &MaintenanceWindows{client: c}
 }
 
+// Find returns all maintenance windows filtered by the given search conditions.
+// If filter is nil, all maintenance windows are returned.
+func (m *MaintenanceWindows) Find(filter []*SearchCondition) (
+	results []*MaintenanceWindow, err error) {
+	err = doSearch(filter, "maintenancewindow", m.client, &results)
+	return
+}
+
 // GetByID returns the MaintenanceWindow with given ID. If no such
 // MaintenanceWindow exists, GetByID returns an error. The caller can call
 // NotFound on err to determine whether or not the error is because the

--- a/role.go
+++ b/role.go
@@ -1,7 +1,6 @@
 package wavefront
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
@@ -30,33 +29,9 @@ func (c *Client) Roles() *Roles {
 	return &Roles{client: c}
 }
 
-func (r Roles) Find(filter []*SearchCondition) ([]*Role, error) {
-	search := &Search{
-		client: r.client,
-		Type:   "role",
-		Params: &SearchParams{
-			Conditions: filter,
-		},
-	}
-
-	var results []*Role
-	moreItems := true
-	for moreItems {
-		resp, err := search.Execute()
-		if err != nil {
-			return nil, err
-		}
-		var tmpres []*Role
-		err = json.Unmarshal(resp.Response.Items, &tmpres)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, tmpres...)
-		moreItems = resp.Response.MoreItems
-		search.Params.Offset = resp.NextOffset
-	}
-
-	return results, nil
+func (r Roles) Find(filter []*SearchCondition) (roles []*Role, err error) {
+	err = doSearch(filter, "role", r.client, &roles)
+	return
 }
 
 func (r Roles) Create(role *Role) error {

--- a/serviceaccount.go
+++ b/serviceaccount.go
@@ -93,6 +93,14 @@ func (c *Client) ServiceAccounts() *ServiceAccounts {
 	return &ServiceAccounts{client: c}
 }
 
+// Find returns all service accounts filtered by the given search conditions.
+// If filter is nil, all service accounts are returned.
+func (s *ServiceAccounts) Find(filter []*SearchCondition) (
+	results []*ServiceAccount, err error) {
+	err = doSearch(filter, "serviceaccount", s.client, &results)
+	return
+}
+
 // GetByID returns the ServiceAccount with given ID. If no such
 // ServiceAccount exists, GetByID returns an error. The caller can call
 // NotFound on err to determine whether or not the error is because the

--- a/target.go
+++ b/target.go
@@ -1,7 +1,6 @@
 package wavefront
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
@@ -95,33 +94,10 @@ func (t Targets) Get(target *Target) error {
 
 // Find returns all targets filtered by the given search conditions.
 // If filter is nil, all targets are returned.
-func (t Targets) Find(filter []*SearchCondition) ([]*Target, error) {
-	search := &Search{
-		client: t.client,
-		Type:   "notificant",
-		Params: &SearchParams{
-			Conditions: filter,
-		},
-	}
-
-	var results []*Target
-	moreItems := true
-	for moreItems {
-		resp, err := search.Execute()
-		if err != nil {
-			return nil, err
-		}
-		var tmpres []*Target
-		err = json.Unmarshal(resp.Response.Items, &tmpres)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, tmpres...)
-		moreItems = resp.Response.MoreItems
-		search.Params.Offset = resp.NextOffset
-	}
-
-	return results, nil
+func (t Targets) Find(filter []*SearchCondition) (
+	results []*Target, err error) {
+	err = doSearch(filter, "notificant", t.client, &results)
+	return
 }
 
 // Create is used to create a Target in Wavefront.

--- a/user.go
+++ b/user.go
@@ -90,33 +90,9 @@ func (u Users) Get(user *User) error {
 // Find returns all Users filtered by the given search conditions.
 // If filter is nil, all Users are returned.
 // UserGroups returned on the User from this call will be ID only
-func (u Users) Find(filter []*SearchCondition) ([]*User, error) {
-	search := &Search{
-		client: u.client,
-		Type:   "user",
-		Params: &SearchParams{
-			Conditions: filter,
-		},
-	}
-
-	var results []*User
-	moreItems := true
-	for moreItems {
-		resp, err := search.Execute()
-		if err != nil {
-			return nil, err
-		}
-		var tmpres []*User
-		err = json.Unmarshal(resp.Response.Items, &tmpres)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, tmpres...)
-		moreItems = resp.Response.MoreItems
-		search.Params.Offset = resp.NextOffset
-	}
-
-	return results, nil
+func (u Users) Find(filter []*SearchCondition) (users []*User, err error) {
+	err = doSearch(filter, "user", u.client, &users)
+	return
 }
 
 // Does not support specifying a credential

--- a/usergroup.go
+++ b/usergroup.go
@@ -1,7 +1,6 @@
 package wavefront
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
@@ -84,33 +83,10 @@ func (g UserGroups) Get(userGroup *UserGroup) error {
 
 // Find returns all UsersGroups filtered by the given search conditions.
 // If filter is nil, all UserGroups are returned.
-func (g UserGroups) Find(filter []*SearchCondition) ([]*UserGroup, error) {
-	search := &Search{
-		client: g.client,
-		Type:   "usergroup",
-		Params: &SearchParams{
-			Conditions: filter,
-		},
-	}
-
-	var results []*UserGroup
-	moreItems := true
-	for moreItems {
-		resp, err := search.Execute()
-		if err != nil {
-			return nil, err
-		}
-		var tmpres []*UserGroup
-		err = json.Unmarshal(resp.Response.Items, &tmpres)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, tmpres...)
-		moreItems = resp.Response.MoreItems
-		search.Params.Offset = resp.NextOffset
-	}
-
-	return results, nil
+func (g UserGroups) Find(filter []*SearchCondition) (
+	results []*UserGroup, err error) {
+	err = doSearch(filter, "usergroup", g.client, &results)
+	return
 }
 
 // Update does not support updating the users on the group


### PR DESCRIPTION
Also add Find methods for service accounts and maintenance windows.