### PR TITLE
Add ChartAttributes to dashboard charts.

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -145,6 +145,9 @@ type Chart struct {
 
 	// ChartSettings are custom settings for the chart
 	ChartSettings ChartSetting `json:"chartSettings"`
+
+	// ChartAttributes is arbitrary JSON used to configure chart attributes
+	ChartAttributes json.RawMessage `json:"chartAttributes,omitempty"`
 }
 
 // Source represents a single Source for a Chart


### PR DESCRIPTION
RawMessage is the way that go embeds arbitrary json.  However, the wavefront REST API that updates a dashboard includes `chartAttributes: null` in the response json when the request payload doesn't include a chartAttributes line.  This is unfortunate because if the caller of the go-wavefront-api doesn't specify chartAttributes, the chartAttributes still comes back as [110, 117, 108, 108] which spells "null" instead of coming back as empty.  