### PR TITLE
Use milliseconds instead of seconds for query StartTime and EndTime

### DIFF
--- a/event_test.go
+++ b/event_test.go
@@ -46,7 +46,7 @@ func TestEvents_Find(t *testing.T) {
 			T: t,
 		},
 	}
-	tr, _ := NewTimeRange(1498723080, LastHour)
+	tr, _ := NewTimeRange(1498723080, LastHour/1000)
 	events, err := e.Find(nil, tr)
 
 	if err != nil {

--- a/query.go
+++ b/query.go
@@ -101,7 +101,7 @@ type TimeSeries struct {
 const (
 	baseQueryPath = "/api/v2/chart/api"
 	// some constants provided for time convenience
-	LastHour    = 60 * 60
+	LastHour    = 60 * 60 * 1000
 	Last3Hours  = LastHour * 3
 	Last6Hours  = LastHour * 6
 	Last24Hours = LastHour * 24
@@ -112,7 +112,7 @@ const (
 // NewQueryParams takes a query string and returns a set of QueryParams with
 // a query window of one hour since now and a set of sensible default vakues
 func NewQueryParams(query string) *QueryParams {
-	endTime := time.Now().Unix()
+	endTime := time.Now().UnixMilli()
 	startTime := endTime - LastHour
 	return &QueryParams{
 		QueryString: query,
@@ -124,7 +124,7 @@ func NewQueryParams(query string) *QueryParams {
 }
 
 func NewQueryParamsNoStrict(query string) *QueryParams {
-	endTime := time.Now().Unix()
+	endTime := time.Now().UnixMilli()
 	startTime := endTime - LastHour
 	return &QueryParams{
 		QueryString: query,
@@ -204,13 +204,13 @@ func (q *Query) SetStartTime(seconds int64) error {
 	if err != nil {
 		return err
 	}
-	q.Params.StartTime = strconv.FormatInt(int64(end)-seconds, 10)
+	q.Params.StartTime = strconv.FormatInt(int64(end)-(seconds*1000), 10)
 	return nil
 }
 
 // SetEndTime sets the time at which the query should end
 func (q *Query) SetEndTime(endTime time.Time) {
-	q.Params.EndTime = strconv.FormatInt(endTime.Unix(), 10)
+	q.Params.EndTime = strconv.FormatInt(endTime.UnixMilli(), 10)
 }
 
 func (qr *QueryResponse) UnmarshalJSON(data []byte) error {

--- a/query_example_test.go
+++ b/query_example_test.go
@@ -28,7 +28,7 @@ func ExampleQuery() {
 	))
 
 	// Set the query period to be one day instead of one hour
-	err = query.SetStartTime(24 * 60 * 60)
+	err = query.SetStartTime(24 * 60 * 60 * 1000)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -44,12 +44,12 @@ func TestQuery(t *testing.T) {
 	// check correct default timewindow applied
 	end, _ := strconv.Atoi(q.Params.EndTime)
 	start, _ := strconv.Atoi(q.Params.StartTime)
-	if end-start != 3600 {
-		t.Errorf("query window, expected 3600, got %d", end-start)
+	if end-start != (3600 * 1000) {
+		t.Errorf("query window, expected 3600000, got %d", end-start)
 	}
 
 	q.SetEndTime(time.Now())
-	assert.NoError(q.SetStartTime(LastDay))
+	assert.NoError(q.SetStartTime(LastDay / 1000))
 	end, _ = strconv.Atoi(q.Params.EndTime)
 	start, _ = strconv.Atoi(q.Params.StartTime)
 	if end-start != LastDay {


### PR DESCRIPTION
The wavefront query API expects the start and end times to be in milliseconds. This client passes it in seconds. Change it to milliseconds.