### PR TITLE
Add missing alert parameters

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -11,6 +11,12 @@ const (
 	AlertTypeClassic   = "CLASSIC"
 )
 
+type AlertTriageDashboard struct {
+	DashboardId string                       `json:"dashboardId"`
+	Parameters  map[string]map[string]string `json:"parameters"`
+	Description string                       `json:"description"`
+}
+
 // Alert represents a single Wavefront Alert
 type Alert struct {
 	// Name is the name given to an Alert
@@ -81,6 +87,12 @@ type Alert struct {
 
 	// Include obsolete metrics in alert query
 	IncludeObsoleteMetrics bool `json:"includeObsoleteMetrics,omitempty"`
+
+	// User-supplied runbook links for this alert
+	RunbookLinks []string `json:"runbookLinks"`
+
+	// User-supplied dashboard and parameters to create dashboard links
+	AlertTriageDashboards []AlertTriageDashboard `json:"alertTriageDashboards"`
 }
 
 type SourceLabelPair struct {

--- a/alert_test.go
+++ b/alert_test.go
@@ -54,7 +54,7 @@ func (m *MockCrudAlertClient) Do(req *http.Request) (io.ReadCloser, error) {
 	return testDo(m.T, req, "./fixtures/create-alert-response.json", m.method, &Alert{})
 }
 
-func TestAlerts_CreateUpdateDeleteAlert(t *testing.T) {
+func TestAlerts_CRUDAlert(t *testing.T) {
 	assert := asserts.New(t)
 	baseurl, _ := url.Parse("http://testing.wavefront.com")
 	a := &Alerts{
@@ -81,13 +81,19 @@ func TestAlerts_CreateUpdateDeleteAlert(t *testing.T) {
 		AdditionalInfo:      "please resolve this alert",
 		Tags:                []string{"mytag1", "mytag2"},
 	}
+	var readAlert Alert
+	alertId := "1234"
 
 	// Update should fail because no ID is set
 	assert.Error(a.Update(&alert))
 
 	a.client.(*MockCrudAlertClient).method = "POST"
 	assert.NoError(a.Create(&alert))
-	assert.Equal("1234", *alert.ID)
+	assert.Equal(alertId, *alert.ID)
+
+	a.client.(*MockCrudAlertClient).method = "GET"
+	readAlert.ID = &alertId
+	assert.NoError(a.Get(&readAlert))
 
 	a.client.(*MockCrudAlertClient).method = "PUT"
 	assert.NoError(a.Update(&alert))
@@ -130,13 +136,19 @@ func TestMultiThresholdAlerts_CreateUpdateDeleteAlert(t *testing.T) {
 		AdditionalInfo:      "please resolve this alert",
 		Tags:                []string{"mytag1", "mytag2"},
 	}
+	var readAlert Alert
+	alertId := "1234"
 
 	// Update should fail because no ID is set
 	assert.Error(a.Update(&alert))
 
 	a.client.(*MockCrudAlertClient).method = "POST"
 	assert.NoError(a.Create(&alert))
-	assert.Equal("1234", *alert.ID)
+	assert.Equal(alertId, *alert.ID)
+
+	a.client.(*MockCrudAlertClient).method = "GET"
+	readAlert.ID = &alertId
+	assert.NoError(a.Get(&readAlert))
 
 	a.client.(*MockCrudAlertClient).method = "PUT"
 	assert.NoError(a.Update(&alert))


### PR DESCRIPTION
Adding parameters that are present in the Wavefront API but not in this client:

- runbookLinks
- alertTriageDashboards